### PR TITLE
Fix flaky test exportDomainArtifacts

### DIFF
--- a/dddplus-test/src/test/java/io/github/dddplus/runtime/registry/IntegrationTest.java
+++ b/dddplus-test/src/test/java/io/github/dddplus/runtime/registry/IntegrationTest.java
@@ -614,7 +614,8 @@ public class IntegrationTest {
         assertTrue(artifacts.getSteps().containsKey(Steps.Submit.Activity));
         List<DomainArtifacts.Step> submitSteps = artifacts.getSteps().get(Steps.Submit.Activity);
         assertEquals(4, submitSteps.size()); // FooStep, BarStep, BazStep, HamStep
-        assertEquals(Steps.Submit.GoodsValidationGroup, submitSteps.get(0).getTags()[0]);
+        assertTrue(submitSteps.stream().anyMatch(step -> step.getTags().length > 0 &&
+            step.getTags()[0].equals(Steps.Submit.GoodsValidationGroup)));
 
         // extensions: IFooExt IMultiMatchExt IReviseStepsExt IDecideStepsExt IPartnerExt IPatternOnlyExt
         assertEquals(7, artifacts.getExtensions().size());


### PR DESCRIPTION
This PR is to fix a flaky test `io.github.dddplus.runtime.registry.IntegrationTest#exportDomainArtifacts` in module `dddplus-test`.

### Setup:
```
Java version: 1.8.0_382
Maven version: Apache Maven 3.6.3
```

### Test failure Reproduction:

Test `io.github.dddplus.runtime.registry.IntegrationTest.exportDomainArtifacts` can fail as the underlying code uses a `HashMap` and assumes the order of values returned by the `.values()` function. This issue was verified using the NonDex [plugin](https://github.com/TestingResearchIllinois/NonDex).

Steps:
```
git clone https://github.com/funkygao/cp-ddd-framework
cd cp-ddd-framework
mvn install -pl dddplus-test -am -DskipTests
mvn -pl dddplus-test edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=io.github.dddplus.runtime.registry.IntegrationTest#exportDomainArtifacts -DnondexMode=ONE
```
NonDex test failure:
```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.002 s <<< FAILURE! - in io.github.dddplus.runtime.registry.IntegrationTest
[ERROR] io.github.dddplus.runtime.registry.IntegrationTest.exportDomainArtifacts  Time elapsed: 0.001 s  <<< ERROR!
java.lang.ArrayIndexOutOfBoundsException: 0
	at io.github.dddplus.runtime.registry.IntegrationTest.exportDomainArtifacts(IntegrationTest.java:617)
```
The tool flags the test as failed even in the `ONE` mode, which means that the map's keys are shuffled only once and every call to the map produces the same shuffled order.

### Root cause and fix:
The test has been setup to register 4 submit activities with codes `Bar`, `Baz`, `Foo` and `Ham` as indicated by debug logs:
```
2023-09-23 10:28:19,966 [main] DEBUG [io.github.dddplus.runtime.registry.InternalIndexer] [232] - indexed StepDef(activity=Submit, code=Bar, name=, tags=[goodsValidation], stepBean=io.github.dddplus.runtime.registry.mock.step.BarStep@2d8f2f3a) 
2023-09-23 10:28:19,980 [main] DEBUG [io.github.dddplus.runtime.registry.InternalIndexer] [232] - indexed StepDef(activity=Submit, code=Baz, name=, tags=[], stepBean=io.github.dddplus.runtime.registry.mock.step.BazStep@2024293c) 
2023-09-23 10:28:19,981 [main] DEBUG [io.github.dddplus.runtime.registry.InternalIndexer] [232] - indexed StepDef(activity=Cancel, code=Egg, name=, tags=[], stepBean=io.github.dddplus.runtime.registry.mock.step.EggStep@7048f722) 
2023-09-23 10:28:19,992 [main] DEBUG [io.github.dddplus.runtime.registry.InternalIndexer] [232] - indexed StepDef(activity=Submit, code=Foo, name=foo活动, tags=[goodsValidation], stepBean=io.github.dddplus.runtime.registry.mock.step.FooStep@58a55449) 
2023-09-23 10:28:19,994 [main] DEBUG [io.github.dddplus.runtime.registry.InternalIndexer] [232] - indexed StepDef(activity=Submit, code=Ham, name=, tags=[], stepBean=io.github.dddplus.runtime.registry.mock.step.HamStep@5949eba8) 
```
Only Foo and Bar steps have a `goodsValidation` tag.

The `DomainArtifacts.Step` objects for a specific activity (`Steps.Submit.Activity` in this [case](https://github.com/rRajivramachandran/cp-ddd-framework/blob/a2e4343e47925d1098b75e3173504bbfdd22956f/dddplus-test/src/test/java/io/github/dddplus/runtime/registry/IntegrationTest.java#L615)), are added as a list of values to a map, with key as activity [here](https://github.com/rRajivramachandran/cp-ddd-framework/blob/a2e4343e47925d1098b75e3173504bbfdd22956f/dddplus-runtime/src/main/java/io/github/dddplus/runtime/registry/DomainArtifacts.java#L61). The 1st element of this list is asserted to have a `goodsValidation` tag in the test [here](https://github.com/rRajivramachandran/cp-ddd-framework/blob/a2e4343e47925d1098b75e3173504bbfdd22956f/dddplus-test/src/test/java/io/github/dddplus/runtime/registry/IntegrationTest.java#L617). This expectation fails when the first element of the list is neither `Foo` nor `Bar`.

The list will not guarantee any ordering, as it is being populated in the order returned by `.values()` [here](https://github.com/rRajivramachandran/cp-ddd-framework/blob/a2e4343e47925d1098b75e3173504bbfdd22956f/dddplus-runtime/src/main/java/io/github/dddplus/runtime/registry/DomainArtifacts.java#L60), of a `HashMap` [here](https://github.com/rRajivramachandran/cp-ddd-framework/blob/a2e4343e47925d1098b75e3173504bbfdd22956f/dddplus-runtime/src/main/java/io/github/dddplus/runtime/registry/InternalIndexer.java#L223), which itself makes no guarentees on order.

To fix the test expectation, we only filter for steps that have a non empty tag and assert that any of these steps tags have a value of `goodsValidation`, instead of the first one. This removes test flakiness with minimal changes. 
The latest test expectation does not look at: a) which specific step has this tag and b) how many steps have the tag, as the original test does not have any expectation/assertions for these. The change continues to maintain this test logic.

The test was rerun using the NonDex plugin and passes after the fix.